### PR TITLE
Fix: evaluation bug on dataset and configuration on device setting

### DIFF
--- a/scripts/eval/configs/h1_internvla_n1_cfg.py
+++ b/scripts/eval/configs/h1_internvla_n1_cfg.py
@@ -27,7 +27,7 @@ eval_cfg = EvalCfg(
             'num_history': 8,
             'num_future_steps': 4,
             
-            'device': 'cuda:1',
+            'device': 'cuda:0',
             'predict_step_nums': 32,
             'continuous_traj': True, 
             # debug

--- a/scripts/eval/configs/vln_r2r.yaml
+++ b/scripts/eval/configs/vln_r2r.yaml
@@ -73,5 +73,5 @@ habitat:
   dataset:
     type: R2RVLN-v1
     split: val_seen
-    scenes_dir: data/scene_datasets/
-    data_path: data/dataset/r2r/R2R_VLNCE_v1-3/{split}/{split}.json.gz
+    scenes_dir: data/scene_data/
+    data_path: data/vln_ce/raw_data/r2r/{split}/{split}.json.gz


### PR DESCRIPTION
The dataset url is incorrect, and I think there are more bugs like this. Please fix the url reference, making it consistent with the tutorial dataset structure:
<img width="730" height="656" alt="image" src="https://github.com/user-attachments/assets/2d1d9570-1080-4b88-89d1-c733b540f821" />

The other bug is 'cuda:1', which is inoperable in the computer with only 1 GPU.
