### PR TITLE
fix: pass depth_anything_checkpoint from config to RGBDBackbone

### DIFF
--- a/internnav/model/basemodel/navdp/navdp_policy.py
+++ b/internnav/model/basemodel/navdp/navdp_policy.py
@@ -83,8 +83,10 @@ class NavDPNet(PreTrainedModel):
         self.token_dim = self.config.model_cfg['il']['token_dim']
         self.scratch = self.config.model_cfg['il']['scratch']
         self.finetune = self.config.model_cfg['il']['finetune']
+        _da_ckpt = self.config.model_cfg['il'].get('depth_anything_checkpoint')
         self.rgbd_encoder = RGBDBackbone(
-            self.image_size, self.token_dim, memory_size=self.memory_size, finetune=self.finetune, device=self._device
+            self.image_size, self.token_dim, memory_size=self.memory_size, finetune=self.finetune, device=self._device,
+            **({'checkpoint': _da_ckpt} if _da_ckpt else {}),
         )
         self.pixel_encoder = PixelGoalBackbone(
             self.image_size, self.token_dim, pixel_channel=self.pixel_channel, device=self._device


### PR DESCRIPTION
## Summary
- Forward `depth_anything_checkpoint` from `model_cfg['il']` to `RGBDBackbone` in `NavDPNet.__init__`
- Previously `RGBDBackbone` always used its hardcoded default path (`checkpoints/depth_anything_v2_vits.pth`), ignoring the config value
- This broke in containerized environments (e.g. Docker with a different working directory) where the relative default path doesn't resolve correctly

## Test plan
- [ ] Verify NavDP eval works with `depth_anything_checkpoint` set in config
- [ ] Verify backward compatibility when `depth_anything_checkpoint` is not set (falls back to existing default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)